### PR TITLE
Create a Docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+tags

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:alpine3.12
+
+ARG version
+
+RUN apk add --no-cache --virtual build-dependencies \
+      build-base \
+      linux-headers \
+    && apk add --no-cache \
+      supervisor \
+    && pip install --upgrade \
+      pip \
+      metrics2mqtt==${version} \
+    && apk del build-dependencies
+
+# Copy configuration files:
+COPY supervisor.conf /etc/supervisor.conf
+COPY run.sh /usr/local/bin/run.sh
+
+# Run:
+ENTRYPOINT ["/usr/local/bin/run.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:alpine3.12
 
-ARG version
-
 RUN apk add --no-cache --virtual build-dependencies \
       build-base \
       linux-headers \
@@ -9,7 +7,7 @@ RUN apk add --no-cache --virtual build-dependencies \
       supervisor \
     && pip install --upgrade \
       pip \
-      metrics2mqtt==${version} \
+      metrics2mqtt==0.1.14 \
     && apk del build-dependencies
 
 # Copy configuration files:

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+if [ -z "${MQTT_BROKER}" ]; then
+    echo 'Missing required environment variable: $MQTT_BROKER'
+    exit 1
+fi
+
+if [ -z "${MQTT_USERNAME}" ]; then
+    echo 'Missing required environment variable: $MQTT_USERNAME'
+    exit 1
+fi
+
+if [ -z "${MQTT_PASSWORD}" ]; then
+    echo 'Missing required environment variable: $MQTT_PASSWORD'
+    exit 1
+fi
+
+M2M_OPTIONS_STRING="--broker ${MQTT_BROKER} --username ${MQTT_USERNAME} --password ${MQTT_PASSWORD}"
+
+if [ ! -z "${COMMAND_OPTIONS_STRING}" ]; then
+    M2M_OPTIONS_STRING="${M2M_OPTIONS_STRING} ${COMMAND_OPTIONS_STRING}"
+fi
+
+# Store the options string as an environment variable that supervisor can use:
+export M2M_OPTIONS_STRING
+
+/usr/bin/supervisord -c /etc/supervisor.conf

--- a/docker/supervisor.conf
+++ b/docker/supervisor.conf
@@ -1,0 +1,9 @@
+[supervisord]
+nodaemon=true
+loglevel=info
+
+[program:metrics2mqtt]
+command=metrics2mqtt %(ENV_M2M_COMMAND_STRING)s
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+redirect_stderr=true


### PR DESCRIPTION
This PR is a part of https://github.com/jamiebegin/metrics2mqtt/issues/2 and adds a `docker` folder that contains everything needed to build a Docker image of `metrics2mqtt`. It uses environment variables to define configuration parameters:

* `COMMAND_OPTIONS_STRING`: a string of options to send to the `metrics2mqtt` command (e.g., `--cpu=60`)
* `MQTT_BROKER`: the hostname/IP of the MQTT broker
* `MQTT_PASSWORD`: the MQTT password
* `MQTT_USERNAME`: the MQTT username

Raw usage:

```
$ docker run -it -v /proc:/proc -e MQTT_BROKER=localhost -e MQTT_USERNAME=username -e MQTT_PASSWORD=password123 -e COMMAND_OPTIONS_STRING='--cpu=60 --interval=10 --vm --du="/" -vvvvv' jamiebegin/metrics2mqtt:0.1.14
```

`docker-compose` usage:

```yaml
---
version: "3"

services:

  metrics2mqtt:
    container_name: metrics2mqtt
    environment:
      COMMAND_OPTIONS_STRING: '--cpu=60 --interval=10 --vm --du="/" -vvvvv'
      MQTT_BROKER: localhost
      MQTT_PASSWORD: password123
      MQTT_USERNAME: username
    image: jamiebegin/metrics2mqtt:0.1.14
    restart: unless-stopped
    volumes:
      - /proc:/proc
```

Notes:

* For MVP, this is a single-architecture image – nothing fancy going on to determine AMD64 vs. ARM, etc. That can be a future PR.
* This assumes the image has been pushed to Docker Hub at `jamiebegin/metrics2mqtt` and tagged with a version consistent with the PyPI package. Obviously, it can be built off of this repo instead.
* We mount `/proc` inside the container so that `metrics2mqtt` looks at the host's metrics, not the container's.
* This PR doesn't modify the README at all; in my experience, we shouldn't give users instructions that point them toward building the image themselves. Rather, after the image is published to Docker Hub, we should create a GitHub action that kicks off Docker Hub builds appropriately (on every push to `master`, every tagged version, etc.). Just a recommendation; open to whatever you want to do here.
* The `Dockerfile` pins the current PyPI version number of `metrics2mqtt` when building. So, each time a new version is released, that version number should be updated there, as well.