### PR TITLE
Create com.jamiebegin.metrics2mqtt.service.plist

### DIFF
--- a/contrib/com.jamiebegin.metrics2mqtt.service.plist
+++ b/contrib/com.jamiebegin.metrics2mqtt.service.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Disabled</key>
+	<false/>
+	<key>KeepAlive</key>
+	<false/>
+	<key>Label</key>
+	<string>com.jamiebegin.metrics2mqtt.service</string>
+	<key>LaunchOnlyOnce</key>
+	<true/>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/bin/metrics2mqtt</string>
+		<string>--name=xxxxxxxx</string>
+		<string>--cpu=60</string>
+		<string>--du="/"</string> 
+		<string>--vm</string> 
+		<string>-vvvv</string>
+		<string>--broker</string>
+		<string>x.x.x.x</string> 
+		<string>--username</string>
+		<string>xxxxx</string>
+		<string>--password</string>
+		<string>xxxxxx</string>
+	</array>
+        <key>RunAtLoad</key>
+	<true/>
+</dict>
+</plist>

--- a/contrib/com.jamiebegin.metrics2mqtt.service.plist
+++ b/contrib/com.jamiebegin.metrics2mqtt.service.plist
@@ -15,7 +15,7 @@
 		<string>/usr/local/bin/metrics2mqtt</string>
 		<string>--name=xxxxxxxx</string>
 		<string>--cpu=60</string>
-		<string>--du="/"</string> 
+		<string>--du=/</string> 
 		<string>--vm</string> 
 		<string>-vvvv</string>
 		<string>--broker</string>


### PR DESCRIPTION
Launcher daemon for MacOS. Needs to be copied to /Library/LaunchDaemons/com.jamiebegin.metrics2mqtt.service.plist
1. Replace xxx's with your hostname (see note below), broker, username and password
2. Make sure permissions are correct:
sudo chmod 600 /Library/LaunchDaemons/com.jamiebegin.metrics2mqtt.service.plist
3. Test with:
sudo launchctl load /Library/LaunchDaemons/com.jamiebegin.metrics2mqtt.service.plist 
then test it's running:
sudo launchctl list | grep com.jamiebegin.metrics2mqtt.service
You should see something like:
1265	0	com.jamiebegin.metrics2mqtt.service
If not, debug with:
sudo tail -n 1000 /var/log/system.log|grep com.jamiebegin.metrics2mqtt.service
4. Load permanently with:
sudo launchctl load -w /Library/LaunchDaemons/com.jamiebegin.metrics2mqtt.service.plist

NOTE: homeassistant is picky about naming in sensors. If your machine has .local, apostrophes or hyphens in the name, it won't be discovered. Message Home Assistant if that's an issue for you!