### PR TITLE
Add basic support for paho.mqtt 2.0+

### DIFF
--- a/metrics2mqtt/base.py
+++ b/metrics2mqtt/base.py
@@ -32,7 +32,12 @@ class MQTTMetrics(object):
         self.deferred_metrics_queue = queue.Queue()
 
     def connect(self):
-        self.client = mqtt.Client(self.system_name + '_metrics2mqtt')
+        if "CallbackAPIVersion" in dir(mqtt):
+            # paho.mqtt 2.0+
+            self.client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, self.system_name + '_metrics2mqtt')
+        else:
+            # paho.mqtt < 2.0
+            self.client = mqtt.Client(self.system_name + '_metrics2mqtt')
         try: 
             if self.username or self.password:
                 self.client.username_pw_set(self.username, self.password)


### PR DESCRIPTION
There's been a change of API for paho.mqtt 2.0 and later so check for the version and support both.

This fixes #15.